### PR TITLE
feature/5-update-readme-about-isobar-ext

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,7 +5,7 @@
 To run a style check with flake8:
 
 ```
-flake8 isobar
+flake8 isobar-ext
 ```
 
 ## Testing
@@ -20,7 +20,7 @@ To generate a unit test coverage report:
 
 ```
 pip3 install pytest-cov
-pytest --cov=isobar tests
+pytest --cov=isobar-ext tests
 ```
 
 To automatically run unit tests on commit:
@@ -56,4 +56,4 @@ To push to PyPi:
 * increment version in `setup.py`
 * `git tag vx.y.z`, `git push --tags`, and create GitHub release
 * `python3 setup.py sdist`
-* `twine upload dist/isobar-x.y.z.tar.gz`
+* `twine upload dist/isobar-ext-x.y.z.tar.gz`

--- a/README.md
+++ b/README.md
@@ -1,17 +1,20 @@
-# isobar
+# isobar-ext
+   <span class="text-small lh-condensed-ultra no-wrap mt-1" data-repository-hovercards-enabled="">
+      forked from <a data-hovercard-type="repository" data-hovercard-url="/ideoforms/isobar/hovercard" class="Link--inTextBlock" href="/ideoforms/isobar">ideoforms/isobar</a>
+    </span>
 
-![ci](https://github.com/ideoforms/isobar/workflows/ci/badge.svg) [![stability-mature](https://img.shields.io/badge/stability-mature-008000.svg)](https://github.com/mkenney/software-guides/blob/master/STABILITY-BADGES.md#mature)
+![ci](https://github.com/piotereks/isobar-ext/workflows/ci/badge.svg) [![stability-mature](https://img.shields.io/badge/stability-mature-008000.svg)](https://github.com/mkenney/software-guides/blob/master/STABILITY-BADGES.md#mature)
 
-isobar is a Python library for creating and manipulating musical patterns, designed for use in algorithmic composition, generative music and sonification. It makes it quick and easy to express complex musical ideas, and can send and receive events from various different sources including MIDI, MIDI files, and OSC.
+isobar-ext is a Python library for creating and manipulating musical patterns, designed for use in algorithmic composition, generative music and sonification. It makes it quick and easy to express complex musical ideas, and can send and receive events from various different sources including MIDI, MIDI files, and OSC.
 
-The core element is a Timeline, which can control its own tempo or sync to an external clock. Onto this, you can schedule Patterns, which can be note sequences, control events, program changes, or other arbitrary events via lambda functions. Pattern are used as templates to generate Events, which trigger notes or control changes on an OutputDevice (Check out a [diagrammatic overview](http://ideoforms.github.io/isobar/#flow-diagram).)
+The core element is a Timeline, which can control its own tempo or sync to an external clock. Onto this, you can schedule Patterns, which can be note sequences, control events, program changes, or other arbitrary events via lambda functions. Pattern are used as templates to generate Events, which trigger notes or control changes on an OutputDevice (Check out a [diagrammatic overview](http://piotereks.github.io/isobar-ext/#flow-diagram).)
 
 isobar includes a large array of basic compositional building blocks (see [Pattern Classes](#pattern-classes)), plus some advanced pattern generators for more sophisticated operations (arpeggiators, Euclidean rhythms, L-systems, Markov chains).
 
 ## Usage
 
 ```python
-import isobar as iso
+import isobar_ext as iso
 
 #------------------------------------------------------------------------
 # Create a geometric series on a minor scale.
@@ -53,13 +56,13 @@ timeline.run()
 
 ## Installation
 
-The short answer: `pip3 install isobar`
+The short answer: `pip3 install isobar-ext` (not yet on PyPl)
 
-The long answer: [isobar Getting Started guide](http://ideoforms.github.io/isobar/getting-started/)
+The long answer: [isobar-ext Getting Started guide](http://piotereks.github.io/isobar-ext/getting-started/)
 
 ## Documentation
 
-For complete documentation, see [ideoforms.github.io/isobar](http://ideoforms.github.io/isobar/).
+For complete documentation, see [piotereks.github.io/isobar-ext](http://piotereks.github.io/isobar-ext/).
 
 ## Examples
 

--- a/auxiliary/scripts/generate-docs.py
+++ b/auxiliary/scripts/generate-docs.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 #------------------------------------------------------------------------
-# Generate isobar README from template and current class docstrings
+# Generate isobar-ext README from template and current class docstrings
 #------------------------------------------------------------------------
 
 import re
@@ -123,7 +123,7 @@ def generate_index(class_data: list[dict]):
         contents += "## [%s](%s/%s)\n" % (file_dict["name"].title(),
                                           file_dict["name"],
                                           "index.md")
-        contents += "View source: [%s.py](https://github.com/ideoforms/isobar/tree/master/isobar/pattern/%s.py)\n\n" % (
+        contents += "View source: [%s.py](https://github.com/piotereks/isobar-ext/tree/master/isobar/pattern/%s.py)\n\n" % (
             file_dict["name"], file_dict["name"])
         contents += "| Class | Function |\n"
         contents += "|-|-|\n"

--- a/auxiliary/scripts/generate-shorthand-aliases.py
+++ b/auxiliary/scripts/generate-shorthand-aliases.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 import re
-import isobar
+import isobar_ext
 
 def main():
 	classes = vars(isobar)

--- a/docs/about.md
+++ b/docs/about.md
@@ -1,5 +1,5 @@
 # About the project
 
-isobar was first designed for the generative sound installation [Variable 4](http://www.variable4.org.uk), in which it was used to generate musical structures in response to changing weather conditions. It was more recently used in [The Listening Machine](http://www.thelisteningmachine.org/), taking live input from Twitter and generating musical output from language patterns, streamed live over the internet.
+isobar-ext was first designed for the generative sound installation [Variable 4](http://www.variable4.org.uk), in which it was used to generate musical structures in response to changing weather conditions. It was more recently used in [The Listening Machine](http://www.thelisteningmachine.org/), taking live input from Twitter and generating musical output from language patterns, streamed live over the internet.
 
 Many of the concepts behind Pattern and its subclasses are inspired by the brilliant pattern library of the [SuperCollider](https://supercollider.github.io/) synthesis language.

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -2,4 +2,4 @@
 
 Third-party contributions are welcomed.
 
-Please read the [CONTRIBUTING.md](https://github.com/ideoforms/isobar/blob/master/CONTRIBUTING.md), and submit a pull request on [GitHub](https://github.com/ideoforms/isobar).
+Please read the [CONTRIBUTING.md](https://github.com/piotereks/isobar-ext/blob/master/CONTRIBUTING.md), and submit a pull request on [GitHub](https://github.com/piotereks/isobar-ext).

--- a/docs/devices/index.md
+++ b/docs/devices/index.md
@@ -1,6 +1,6 @@
 # Devices and I/O 
 
-isobar can send events to different types of output device.
+isobar-ext can send events to different types of output device.
 
 - [MIDI](midi.md): Send/receive live MIDI note, control and clock events, either to an external MIDI hardware device or software DAW
 - [MIDI file](midifile.md): Generate and store MIDI sequences in a .mid file

--- a/docs/devices/midi.md
+++ b/docs/devices/midi.md
@@ -1,12 +1,12 @@
 # MIDI
 
-isobar's MIDI support is based on the excellent [mido](https://mido.readthedocs.io/en/latest/) library. 
+isobar-ext's MIDI support is based on the excellent [mido](https://mido.readthedocs.io/en/latest/) library. 
 
 Two classes are available for MIDI I/O:
 
 ## MidiOutputDevice
 
-Sends note and control events to a MIDI device. isobar can also act as the clock out, so that external MIDI devices follow isobar's internal clock.  
+Sends note and control events to a MIDI device. isobar-ext can also act as the clock out, so that external MIDI devices follow isobar's internal clock.  
 
 !!! info "Virtual MIDI devices" 
     To control a MIDI device on the same computer that is running isobar, you will need to create a [virtual MIDI bus](virtual-midi-devices.md).

--- a/docs/devices/midifile.md
+++ b/docs/devices/midifile.md
@@ -4,7 +4,7 @@
 
 Writing MIDI files is done by setting the output device of a Timeline to a `MidiFileOutputDevice`
 
-isobar normally generates events in real-time according to the tempo of the Timeline. To batch process events instantaneously, set the tempo of the timeline to `iso.MAX_CLOCK_RATE`. 
+isobar-ext normally generates events in real-time according to the tempo of the Timeline. To batch process events instantaneously, set the tempo of the timeline to `iso.MAX_CLOCK_RATE`. 
 
 ```
 filename = "output.mid"

--- a/docs/devices/virtual-midi-devices.md
+++ b/docs/devices/virtual-midi-devices.md
@@ -1,5 +1,5 @@
 # Virtual MIDI Devices
 
-To send MIDI events to audio software running on the same computer (for example, to use isobar to trigger events in your DAW), you will generally need to set up a *virtual MIDI driver*. This lets you send MIDI messages between different applications.
+To send MIDI events to audio software running on the same computer (for example, to use isobar-ext to trigger events in your DAW), you will generally need to set up a *virtual MIDI driver*. This lets you send MIDI messages between different applications.
 
 For cross-platform instructions on how to do this, see [Setting up a virtual MIDI bus](https://help.ableton.com/hc/en-us/articles/209774225-How-to-setup-a-virtual-MIDI-bus) (Ableton).

--- a/docs/events/control.md
+++ b/docs/events/control.md
@@ -14,7 +14,7 @@ The above example sets control index `0` to a value drawn from a uniformly distr
 
 ## Interpolation
 
-To transmit smooth control curves, isobar can interpolate between control values. The resulting interpolated value is sent continuously to the output device.
+To transmit smooth control curves, isobar-ext can interpolate between control values. The resulting interpolated value is sent continuously to the output device.
 
 ```python
 # Apply linear interpolation to smoothly fade between values.

--- a/docs/events/note.md
+++ b/docs/events/note.md
@@ -2,7 +2,7 @@
 
 ## Notes and names
 
-A common approach to composition in isobar is building up patterns of notes, which correspond to the standard MIDI note range (0..127, with 60 = middle C) and velocity range (0..127).
+A common approach to composition in isobar-ext is building up patterns of notes, which correspond to the standard MIDI note range (0..127, with 60 = middle C) and velocity range (0..127).
 
 ```python
 timeline.schedule({

--- a/docs/example.md
+++ b/docs/example.md
@@ -1,6 +1,6 @@
-# isobar
+# isobar-ext
 
-isobar is a Python library for creating and manipulating musical patterns, designed for use in algorithmic composition, generative music and sonification. It makes it quick and easy to express complex musical ideas, and can send and receive events from various different sources: MIDI, OSC, SocketIO, and .mid files.
+isobar-ext is a Python library for creating and manipulating musical patterns, designed for use in algorithmic composition, generative music and sonification. It makes it quick and easy to express complex musical ideas, and can send and receive events from various different sources: MIDI, OSC, SocketIO, and .mid files.
 
 ## Documentation
 

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -1,7 +1,7 @@
 # Examples
 
-A complete set of example scripts are included with isobar, demonstrating applications from simple sequencing functionality to more complex tasks such as clock sync, file I/O, etc.
+A complete set of example scripts are included with isobar-ext, demonstrating applications from simple sequencing functionality to more complex tasks such as clock sync, file I/O, etc.
 
-[Examples](https://github.com/ideoforms/isobar/tree/master/examples)
+[Examples](https://github.com/piotereks/isobar-ext/tree/master/examples)
 
-Alternatively, to see how every function across the codebase can be used, browse the [unit tests](https://github.com/ideoforms/isobar/tree/master/tests).
+Alternatively, to see how every function across the codebase can be used, browse the [unit tests](https://github.com/piotereks/isobar-ext/tree/master/tests).

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -2,9 +2,9 @@
 
 ## Requirements
 
-isobar has been tested on Linux (Ubuntu, Raspberry Pi OS) and macOS. It has not been officially tested on Windows, although third-party contributions of support and QA efforts would be welcomed.
+isobar-ext has been tested on Linux (Ubuntu, Raspberry Pi OS) and macOS. It has not been officially tested on Windows, although third-party contributions of support and QA efforts would be welcomed. (to be verified)
 
-It requires Python 3.5 or above. 
+It requires Python 3.5 or above. (to be verified rather 3.9+)
 
 On Linux, the `libasound` and `libjack-dev` packages are also required:
 
@@ -12,26 +12,26 @@ On Linux, the `libasound` and `libjack-dev` packages are also required:
 apt install libasound2-dev libjack-dev
 ```
 
-### 1. Install isobar
+### 1. Install isobar-ext
 
 The simplest way to install isobar is via `pip`:
 
 ```python
-pip3 install isobar
+pip3 install isobar-ext
 ```
 
 To download the examples, you will need to clone the repo and install from source:
 
 ```python
-git clone https://github.com/ideoforms/isobar.git
-cd isobar
+git clone https://github.com/pioteresk/isobar-ext.git
+cd isobar-ext
 pip3 install .
 ```
 
 ### 2. Set up an output device
 
 The example scripts are based on sending MIDI to a DAW or MIDI-compatible hardware instrument.
-By default, isobar uses the system's default MIDI output as its output device.
+By default, isobar-ext uses the system's default MIDI output as its output device.
 If you want to specify a non-standard MIDI output, you can [specify the name of the MIDI device when creating the Timeline](devices/midi.md), or set a global default output device by using an environmental variable:
 
 ```python
@@ -61,5 +61,5 @@ The script will print the default MIDI driver to screen, and begin triggering no
 
 ## Next steps
 
-- [Code examples](https://github.com/ideoforms/isobar/tree/master/examples)
+- [Code examples](https://github.com/piotereks/isobar-ext/tree/master/examples)
 - Read about [Patterns](patterns/index.md), [Timelines](timelines/index.md), [Events](events/index.md) and [Devices](devices/index.md),

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,10 +1,10 @@
-# isobar
+# isobar-ext
 
-isobar is a Python library for creating and manipulating musical patterns, designed for use in algorithmic composition, generative music and sonification. It makes it quick and easy to express complex musical ideas, and can send and receive events from various different sources: MIDI, OSC, SocketIO, and .mid files.
+isobar-ext is a Python library for creating and manipulating musical patterns, designed for use in algorithmic composition, generative music and sonification. It makes it quick and easy to express complex musical ideas, and can send and receive events from various different sources: MIDI, OSC, SocketIO, and .mid files.
 
-### What isobar does
+### What isobar-ext does
 
-The core objective of isobar is to provide a framework for sequencing and triggering events, which may be MIDI messages, OSC events, triggers for third-party DSP engines such as [SuperCollider](https://supercollider.github.io/), or even Python functions. ([What types of event are supported?](events/index.md#event-types)) 
+The core objective of isobar-ext is to provide a framework for sequencing and triggering events, which may be MIDI messages, OSC events, triggers for third-party DSP engines such as [SuperCollider](https://supercollider.github.io/), or even Python functions. ([What types of event are supported?](events/index.md#event-types)) 
 
 It can be used to trigger events in real time, or to generate patterns that can be serialised as MIDI files and loaded into a DAW.
 
@@ -12,7 +12,7 @@ It can sync to external clocks, or act as a clock source to external devices.
 
 It can also load patterns serialised in MIDI files for processing.
 
-### What isobar doesn't do
+### What isobar-ext doesn't do
 
 isobar does not generate any audio on its own. It must be configured to send events to an output device which is responsible for sound synthesis.
 

--- a/docs/license.md
+++ b/docs/license.md
@@ -1,6 +1,6 @@
 # License 
 
-isobar is under the [MIT license](https://github.com/ideoforms/isobar/blob/master/LICENSE.md).
+isobar-ext is under the [MIT license](https://github.com/ideoforms/isobar/blob/master/LICENSE.md).
 
 This means that you are welcome to use it for any purpose, including commercial usage, but must include the copyright notice above in any copies or derivative works.
 

--- a/docs/patterns/index.md
+++ b/docs/patterns/index.md
@@ -78,7 +78,7 @@ The operators are designed to do what you would expect:
  - equality operators (`<`, `>`, `==`, `!=`) can be used to do element-wise comparison on the input sequences, returning a pattern whose values are either `True`, `False` or `None`.
  - `abs()` can be used to generate the absolute values of a sequence
  - For finite sequences, `len()` will return the length of the sequence
- - A `float` pattern can be turned into an `int` pattern with `isobar.PInt(pattern)` 
+ - A `float` pattern can be turned into an `int` pattern with `isobar_ext.PInt(pattern)` 
 
 ## Duplicating patterns
 

--- a/docs/patterns/library.md
+++ b/docs/patterns/library.md
@@ -1,5 +1,5 @@
 ## Core
-View source: [core.py](https://github.com/ideoforms/isobar/tree/master/isobar/pattern/core.py)
+View source: [core.py](https://github.com/piotereks/isobar-ext/tree/master/isobar/pattern/core.py)
 
 | Class | Function |
 |-|-|
@@ -30,7 +30,7 @@ View source: [core.py](https://github.com/ideoforms/isobar/tree/master/isobar/pa
 | PLessThanOrEqual | Return 1 if a <= b, 0 otherwise (shorthand: patternA <= patternB) |
 
 ## Scalar
-View source: [scalar.py](https://github.com/ideoforms/isobar/tree/master/isobar/pattern/scalar.py)
+View source: [scalar.py](https://github.com/piotereks/isobar-ext/tree/master/isobar/pattern/scalar.py)
 
 | Class | Function |
 |-|-|
@@ -48,7 +48,7 @@ View source: [scalar.py](https://github.com/ideoforms/isobar/tree/master/isobar/
 | PIndexOf | Find index of items from `pattern` in <list> |
 
 ## Sequence
-View source: [sequence.py](https://github.com/ideoforms/isobar/tree/master/isobar/pattern/sequence.py)
+View source: [sequence.py](https://github.com/piotereks/isobar-ext/tree/master/isobar/pattern/sequence.py)
 
 | Class | Function |
 |-|-|
@@ -75,7 +75,7 @@ View source: [sequence.py](https://github.com/ideoforms/isobar/tree/master/isoba
 | PSequenceAction | Iterate over an array, perform a function, and repeat. |
 
 ## Chance
-View source: [chance.py](https://github.com/ideoforms/isobar/tree/master/isobar/pattern/chance.py)
+View source: [chance.py](https://github.com/piotereks/isobar-ext/tree/master/isobar/pattern/chance.py)
 
 | Class | Function |
 |-|-|
@@ -92,7 +92,7 @@ View source: [chance.py](https://github.com/ideoforms/isobar/tree/master/isobar/
 | PSwitchOne | Capture `length` input values; loop, repeatedly switching two adjacent values. |
 
 ## Tonal
-View source: [tonal.py](https://github.com/ideoforms/isobar/tree/master/isobar/pattern/tonal.py)
+View source: [tonal.py](https://github.com/piotereks/isobar-ext/tree/master/isobar/pattern/tonal.py)
 
 | Class | Function |
 |-|-|
@@ -102,7 +102,7 @@ View source: [tonal.py](https://github.com/ideoforms/isobar/tree/master/isobar/p
 | PMidiNoteToFrequency | Map MIDI note to frequency value. |
 
 ## Static
-View source: [static.py](https://github.com/ideoforms/isobar/tree/master/isobar/pattern/static.py)
+View source: [static.py](https://github.com/piotereks/isobar-ext/tree/master/isobar/pattern/static.py)
 
 | Class | Function |
 |-|-|
@@ -110,7 +110,7 @@ View source: [static.py](https://github.com/ideoforms/isobar/tree/master/isobar/
 | PCurrentTime | Returns the position (in beats) of the current timeline. |
 
 ## Fade
-View source: [fade.py](https://github.com/ideoforms/isobar/tree/master/isobar/pattern/fade.py)
+View source: [fade.py](https://github.com/piotereks/isobar-ext/tree/master/isobar/pattern/fade.py)
 
 | Class | Function |
 |-|-|
@@ -118,21 +118,21 @@ View source: [fade.py](https://github.com/ideoforms/isobar/tree/master/isobar/pa
 | PFadeNotewiseRandom | Fade a pattern in/out by gradually introducing random notes. |
 
 ## Markov
-View source: [markov.py](https://github.com/ideoforms/isobar/tree/master/isobar/pattern/markov.py)
+View source: [markov.py](https://github.com/piotereks/isobar-ext/tree/master/isobar/pattern/markov.py)
 
 | Class | Function |
 |-|-|
 | PMarkov | First-order Markov chain generator. |
 
 ## Lsystem
-View source: [lsystem.py](https://github.com/ideoforms/isobar/tree/master/isobar/pattern/lsystem.py)
+View source: [lsystem.py](https://github.com/piotereks/isobar-ext/tree/master/isobar/pattern/lsystem.py)
 
 | Class | Function |
 |-|-|
 | PLSystem | integer sequence derived from Lindenmayer systems |
 
 ## Warp
-View source: [warp.py](https://github.com/ideoforms/isobar/tree/master/isobar/pattern/warp.py)
+View source: [warp.py](https://github.com/piotereks/isobar-ext/tree/master/isobar/pattern/warp.py)
 
 | Class | Function |
 |-|-|

--- a/docs/source-code.md
+++ b/docs/source-code.md
@@ -1,11 +1,11 @@
 # Source code
 
-The source code for isobar is hosted on GitHub:
+The source code for isobar-ext is hosted on GitHub:
 
-[github.com/ideoforms/isobar](https://github.com/ideoforms/isobar)
+[github.com/piotereks/isobar-ext](https://github.com/piotereks/isobar-ext)
 
 To clone the latest version:
 
 ```
-git clone https://github.com/ideoforms/isobar.git
+git clone https://github.com/piotereks/isobar-ext.git
 ```

--- a/docs/timelines/index.md
+++ b/docs/timelines/index.md
@@ -72,7 +72,7 @@ timeline.schedule({
 
 ## Clock resolution and accuracy
 
-isobar's internal clock by default has a resolution of 480 ticks per beat (PPQN), which equates to a timing precision of 1ms at 120bpm.
+isobar-ext's internal clock by default has a resolution of 480 ticks per beat (PPQN), which equates to a timing precision of 1ms at 120bpm.
 
 High-precision scheduling in Python is inherently limited by Python's global interpreter lock (GIL), which means that sub-millisecond accuracy is unfortunately not possible. The good news is that, when using Python 3+, jitter is pretty low: the unit test suite verifies that the host device is able to keep time to +/- 1ms, and passes on Linux and macOS. 
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,11 +1,11 @@
-site_name: isobar
+site_name: isobar-ext
 theme:
   name: material
   features:
     - navigation.tabs
 
-repo_name: ideoforms/isobar
-repo_url: https://github.com/ideoforms/isobar
+repo_name: piotereks/isobar-ext
+repo_url: https://github.com/piotereks/isobar-ext
 
 markdown_extensions:
  - markdown.extensions.admonition

--- a/setup.py
+++ b/setup.py
@@ -3,14 +3,14 @@
 from setuptools import setup, find_packages
 
 setup(
-    name='isobar',
+    name='isobar-ext',
     version='0.1.2',
     description='A Python library to express and manipulate musical patterns',
     long_description = open("README.md", "r").read(),
     long_description_content_type = "text/markdown",
     author='Daniel Jones',
-    author_email='dan-isobar@erase.net',
-    url='https://github.com/ideoforms/isobar',
+    author_email='piotereks@gmail.com',
+    url='https://github.com/piotereks/isobar-ext',
     packages=find_packages(),
     install_requires=['python-osc', 'mido', 'python-rtmidi'],
     keywords=['sound', 'music', 'composition'],


### PR DESCRIPTION
- rename of isobar to isobar-ext or isobar_ext
- rename of repository to fork
- rename of references of gitlab pages to fork gitlab pages
